### PR TITLE
1) config & removed, 2) updatedId appended

### DIFF
--- a/examples/tsne/bhtsne/tsne_main.cpp
+++ b/examples/tsne/bhtsne/tsne_main.cpp
@@ -16,7 +16,7 @@ int main(int argv, char *argc[]) {
     if (argv >= 2)
         path = argc[1];
 
-    Config& config = Config::load(path);
+    Config config = Config::load(path);
 
     // Make dummy landmarks
     int* landmarks = (int*)malloc(config.n * sizeof(int));

--- a/examples/tsne/lib/config.cpp
+++ b/examples/tsne/lib/config.cpp
@@ -89,7 +89,7 @@ Config Config::load(const std::string& path) {
     // validate config
     
     if (config.n == 0 || config.input_dims == 0 || config.output_dims == 0 || config.input_path.size() == 0 || config.output_path.size() == 0) {
-        throw std::exception("some of the required fields are missing: check n, input_dims, output_dims, input_path, output_path");
+        throw; // std::exception("some of the required fields are missing: check n, input_dims, output_dims, input_path, output_path");
     }
    
     std::ifstream datafile(config.input_path);

--- a/examples/tsne/responsive_tsne/responsive_tsne_main.cpp
+++ b/examples/tsne/responsive_tsne/responsive_tsne_main.cpp
@@ -16,7 +16,7 @@ int main(int argv, char *argc[]) {
     if (argv >= 2)
         path = argc[1];
 
-    Config& config = Config::load(path);
+    Config config = Config::load(path);
     
     // Make dummy landmarks
     int* landmarks = (int*)malloc(config.n * sizeof(int));

--- a/python/pynene.pxd
+++ b/python/pynene.pxd
@@ -1,5 +1,6 @@
 from cpython cimport PyObject
 from libcpp cimport bool
+from libcpp.set cimport set
 
 from numpy cimport int64_t, int32_t, uint32_t, float64_t
 cimport numpy as np
@@ -91,16 +92,17 @@ cdef extern from "panene_python.h":
         float tableWeight
 
     cdef cppclass UpdateResult:
-      size_t addPointOps
-      size_t updateIndexOps
-      size_t updateTableOps
-      size_t addPointResult
-      size_t updateIndexResult
-      size_t updateTableResult
-      size_t numPointsInserted
-      double addPointElapsed
-      double updateIndexElapsed
-      double updateTableElapsed
+        size_t addPointOps
+        size_t updateIndexOps
+        size_t updateTableOps
+        size_t addPointResult
+        size_t updateIndexResult
+        size_t updateTableResult
+        size_t numPointsInserted
+        double addPointElapsed
+        double updateIndexElapsed
+        double updateTableElapsed
+        set[size_t] updatedIds
 
 
     cdef cppclass PyDataSink:

--- a/python/pynene.pyx
+++ b/python/pynene.pyx
@@ -236,4 +236,5 @@ cdef class KNNTable:
             'addPointElapsed': ur.addPointElapsed,
             'updateIndexElapsed': ur.updateIndexElapsed,
             'updateTableElapsed': ur.updateTableElapsed,
+            'updatedIds': ur.updatedIds,
             }


### PR DESCRIPTION
1. A minor error was found when building in Ubuntu 18.04 environment. Three files regarding config were changed a bit.
- tsne_main.cpp
- responsive_tsne_main.cpp
- config.cpp

2. Once the KNN Table is updated, indexes of dirty points(IDs of updated rows) are required. Now it supports returning them in python as well. Two files are changed.
- pynene.pxd
- pynene.pyx